### PR TITLE
Fix LTR-RTL layout random switching

### DIFF
--- a/app/src/main/java/com/pennywise/app/PennyWiseApplication.kt
+++ b/app/src/main/java/com/pennywise/app/PennyWiseApplication.kt
@@ -62,7 +62,7 @@ class PennyWiseApplication : Application() {
             val resources = resources
             val configuration = Configuration(resources.configuration)
             
-            val locale = resolveAppLocale(languageCode)
+            val locale = resolveAppLocale(languageCode, this)
             
             Locale.setDefault(locale)
             
@@ -93,7 +93,7 @@ class PennyWiseApplication : Application() {
             
             if (!languageCode.isNullOrEmpty()) {
                 // Apply the saved locale
-                val locale = resolveAppLocale(languageCode)
+                val locale = resolveAppLocale(languageCode, context)
                 
                 // Update the configuration
                 val configuration = Configuration(context.resources.configuration)
@@ -125,12 +125,12 @@ class PennyWiseApplication : Application() {
      * Resolves the app locale from a language code and guarantees we only use
      * locales supported by the app to avoid accidental RTL layout flips.
      */
-    private fun resolveAppLocale(languageCode: String?): Locale {
+    private fun resolveAppLocale(languageCode: String?, context: Context? = null): Locale {
         return when {
             languageCode.equals("en", ignoreCase = true) -> Locale("en")
             languageCode.equals("iw", ignoreCase = true) || languageCode.equals("he", ignoreCase = true) -> Locale("iw")
             languageCode.equals("ru", ignoreCase = true) -> Locale("ru")
-            else -> mapSystemLocaleToSupportedLocale()
+            else -> mapSystemLocaleToSupportedLocale(context)
         }
     }
 
@@ -139,13 +139,15 @@ class PennyWiseApplication : Application() {
      * App startup should not depend on device locale for layout direction.
      * Unsupported or missing language settings default to English (LTR).
      */
-    private fun mapSystemLocaleToSupportedLocale(): Locale {
-        val systemLanguage = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            resources.configuration.locales[0]?.language
-        } else {
-            @Suppress("DEPRECATION")
-            resources.configuration.locale?.language
-        }
+    private fun mapSystemLocaleToSupportedLocale(context: Context?): Locale {
+        val systemLanguage = context?.let { safeContext ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                safeContext.resources.configuration.locales[0]?.language
+            } else {
+                @Suppress("DEPRECATION")
+                safeContext.resources.configuration.locale?.language
+            }
+        } ?: Locale.getDefault().language
 
         return when {
             systemLanguage.equals("ru", ignoreCase = true) -> Locale("ru")

--- a/app/src/main/java/com/pennywise/app/PennyWiseApplication.kt
+++ b/app/src/main/java/com/pennywise/app/PennyWiseApplication.kt
@@ -62,12 +62,7 @@ class PennyWiseApplication : Application() {
             val resources = resources
             val configuration = Configuration(resources.configuration)
             
-            val locale = when (languageCode) {
-                "en" -> Locale("en")
-                "iw" -> Locale("iw")
-                "ru" -> Locale("ru")
-                else -> Locale.getDefault()
-            }
+            val locale = resolveAppLocale(languageCode)
             
             Locale.setDefault(locale)
             
@@ -98,12 +93,7 @@ class PennyWiseApplication : Application() {
             
             if (!languageCode.isNullOrEmpty()) {
                 // Apply the saved locale
-                val locale = when (languageCode) {
-                    "en" -> Locale("en")
-                    "iw" -> Locale("iw")
-                    "ru" -> Locale("ru")
-                    else -> Locale.getDefault()
-                }
+                val locale = resolveAppLocale(languageCode)
                 
                 // Update the configuration
                 val configuration = Configuration(context.resources.configuration)
@@ -129,5 +119,27 @@ class PennyWiseApplication : Application() {
             Timber.e(e, "Failed to apply saved locale: ${e.message}")
             context
         }
+    }
+
+    /**
+     * Resolves the app locale from a language code and guarantees we only use
+     * locales supported by the app to avoid accidental RTL layout flips.
+     */
+    private fun resolveAppLocale(languageCode: String?): Locale {
+        return when {
+            languageCode.equals("en", ignoreCase = true) -> Locale("en")
+            languageCode.equals("iw", ignoreCase = true) || languageCode.equals("he", ignoreCase = true) -> Locale("iw")
+            languageCode.equals("ru", ignoreCase = true) -> Locale("ru")
+            else -> mapSystemLocaleToSupportedLocale()
+        }
+    }
+
+    /**
+     * Maps the device locale to a supported app locale.
+     * App startup should not depend on device locale for layout direction.
+     * Unsupported or missing language settings default to English (LTR).
+     */
+    private fun mapSystemLocaleToSupportedLocale(): Locale {
+        return Locale("en")
     }
 }

--- a/app/src/main/java/com/pennywise/app/PennyWiseApplication.kt
+++ b/app/src/main/java/com/pennywise/app/PennyWiseApplication.kt
@@ -9,6 +9,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
+import com.pennywise.app.presentation.util.AppLocaleSupport
 import com.pennywise.app.presentation.util.LocaleManager
 import com.pennywise.app.presentation.util.SettingsManager
 import dagger.hilt.android.HiltAndroidApp
@@ -62,7 +63,7 @@ class PennyWiseApplication : Application() {
             val resources = resources
             val configuration = Configuration(resources.configuration)
             
-            val locale = resolveAppLocale(languageCode, this)
+            val locale = AppLocaleSupport.resolveSupportedLocale(languageCode, this)
             
             Locale.setDefault(locale)
             
@@ -93,7 +94,7 @@ class PennyWiseApplication : Application() {
             
             if (!languageCode.isNullOrEmpty()) {
                 // Apply the saved locale
-                val locale = resolveAppLocale(languageCode, context)
+                val locale = AppLocaleSupport.resolveSupportedLocale(languageCode, context)
                 
                 // Update the configuration
                 val configuration = Configuration(context.resources.configuration)
@@ -121,40 +122,4 @@ class PennyWiseApplication : Application() {
         }
     }
 
-    /**
-     * Resolves the app locale from a language code and guarantees we only use
-     * locales supported by the app to avoid accidental RTL layout flips.
-     */
-    private fun resolveAppLocale(languageCode: String?, context: Context? = null): Locale {
-        return when {
-            languageCode.equals("en", ignoreCase = true) -> Locale("en")
-            languageCode.equals("iw", ignoreCase = true) || languageCode.equals("he", ignoreCase = true) -> Locale("iw")
-            languageCode.equals("ru", ignoreCase = true) -> Locale("ru")
-            else -> mapSystemLocaleToSupportedLocale(context)
-        }
-    }
-
-    /**
-     * Maps the device locale to a supported app locale.
-     * App startup should not depend on device locale for layout direction.
-     * Unsupported or missing language settings default to English (LTR).
-     */
-    private fun mapSystemLocaleToSupportedLocale(context: Context?): Locale {
-        val systemLanguage = context?.let { safeContext ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                safeContext.resources.configuration.locales[0]?.language
-            } else {
-                @Suppress("DEPRECATION")
-                safeContext.resources.configuration.locale?.language
-            }
-        } ?: Locale.getDefault().language
-
-        return when {
-            systemLanguage.equals("ru", ignoreCase = true) -> Locale("ru")
-            systemLanguage.equals("he", ignoreCase = true) ||
-                systemLanguage.equals("iw", ignoreCase = true) -> Locale("iw")
-            systemLanguage.equals("en", ignoreCase = true) -> Locale("en")
-            else -> Locale("en")
-        }
-    }
 }

--- a/app/src/main/java/com/pennywise/app/PennyWiseApplication.kt
+++ b/app/src/main/java/com/pennywise/app/PennyWiseApplication.kt
@@ -140,6 +140,19 @@ class PennyWiseApplication : Application() {
      * Unsupported or missing language settings default to English (LTR).
      */
     private fun mapSystemLocaleToSupportedLocale(): Locale {
-        return Locale("en")
+        val systemLanguage = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            resources.configuration.locales[0]?.language
+        } else {
+            @Suppress("DEPRECATION")
+            resources.configuration.locale?.language
+        }
+
+        return when {
+            systemLanguage.equals("ru", ignoreCase = true) -> Locale("ru")
+            systemLanguage.equals("he", ignoreCase = true) ||
+                systemLanguage.equals("iw", ignoreCase = true) -> Locale("iw")
+            systemLanguage.equals("en", ignoreCase = true) -> Locale("en")
+            else -> Locale("en")
+        }
     }
 }

--- a/app/src/main/java/com/pennywise/app/data/util/SettingsDataStore.kt
+++ b/app/src/main/java/com/pennywise/app/data/util/SettingsDataStore.kt
@@ -148,6 +148,12 @@ class SettingsDataStore @Inject constructor(
         dataStore.edit { preferences ->
             preferences[languageKey] = languageCode
         }
+        // Keep startup locale source in sync with DataStore.
+        context
+            .getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            .edit()
+            .putString("language", languageCode)
+            .apply()
     }
     
     /**

--- a/app/src/main/java/com/pennywise/app/data/util/SettingsDataStore.kt
+++ b/app/src/main/java/com/pennywise/app/data/util/SettingsDataStore.kt
@@ -163,6 +163,12 @@ class SettingsDataStore @Inject constructor(
         dataStore.edit { preferences ->
             preferences[currencyKey] = currencyCode
         }
+        // Keep startup settings source in sync with DataStore.
+        context
+            .getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+            .edit()
+            .putString("currency", currencyCode)
+            .apply()
     }
 
     /**

--- a/app/src/main/java/com/pennywise/app/presentation/MainActivity.kt
+++ b/app/src/main/java/com/pennywise/app/presentation/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.lifecycleScope
 import com.pennywise.app.presentation.theme.PennyWiseThemeWithManager
 import com.pennywise.app.presentation.PennyWiseApp
 import com.pennywise.app.presentation.theme.ThemeManager
+import com.pennywise.app.presentation.util.AppLocaleSupport
 import com.pennywise.app.presentation.util.LocaleManager
 import com.pennywise.app.data.util.SettingsDataStore
 import dagger.hilt.android.AndroidEntryPoint
@@ -51,10 +52,7 @@ class MainActivity : FragmentActivity() {
         setContent {
             PennyWiseThemeWithManager(themeManager = themeManager) {
                 val appLanguage by settingsDataStore.language.collectAsState(initial = initialLanguage)
-                val layoutDirection = if (
-                    appLanguage.equals("iw", ignoreCase = true) ||
-                    appLanguage.equals("he", ignoreCase = true)
-                ) {
+                val layoutDirection = if (AppLocaleSupport.isRtlLanguage(appLanguage)) {
                     LayoutDirection.Rtl
                 } else {
                     LayoutDirection.Ltr

--- a/app/src/main/java/com/pennywise/app/presentation/MainActivity.kt
+++ b/app/src/main/java/com/pennywise/app/presentation/MainActivity.kt
@@ -89,6 +89,10 @@ class MainActivity : FragmentActivity() {
             } else {
                 val detectedLanguage = localeManager.detectDeviceLocale(this@MainActivity)
                 if (detectedLanguage.isNotEmpty()) {
+                    // First-run bootstrap: persist detected locale so Compose can
+                    // derive layout direction from the same source of truth.
+                    settingsDataStore.setLanguage(detectedLanguage)
+                    currentLanguageCode = detectedLanguage
                     applyLocaleChange(detectedLanguage)
                 }
             }

--- a/app/src/main/java/com/pennywise/app/presentation/MainActivity.kt
+++ b/app/src/main/java/com/pennywise/app/presentation/MainActivity.kt
@@ -7,7 +7,12 @@ import androidx.fragment.app.FragmentActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.lifecycle.lifecycleScope
 import com.pennywise.app.presentation.theme.PennyWiseThemeWithManager
 import com.pennywise.app.presentation.PennyWiseApp
@@ -42,12 +47,26 @@ class MainActivity : FragmentActivity() {
         
         setContent {
             PennyWiseThemeWithManager(themeManager = themeManager) {
-                // A surface container using the 'background' color from the theme
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
+                val appLanguage by settingsDataStore.language.collectAsState(initial = "")
+                val layoutDirection = if (
+                    appLanguage.equals("iw", ignoreCase = true) ||
+                    appLanguage.equals("he", ignoreCase = true)
                 ) {
-                    PennyWiseApp()
+                    LayoutDirection.Rtl
+                } else {
+                    LayoutDirection.Ltr
+                }
+
+                // Layout direction follows app language only:
+                // Hebrew => RTL, all other languages => LTR.
+                CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+                    // A surface container using the 'background' color from the theme
+                    Surface(
+                        modifier = Modifier.fillMaxSize(),
+                        color = MaterialTheme.colorScheme.background
+                    ) {
+                        PennyWiseApp()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/pennywise/app/presentation/MainActivity.kt
+++ b/app/src/main/java/com/pennywise/app/presentation/MainActivity.kt
@@ -44,10 +44,13 @@ class MainActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         
         initializeLocale()
+        val initialLanguage = getSharedPreferences("app_preferences", MODE_PRIVATE)
+            .getString("language", "")
+            .orEmpty()
         
         setContent {
             PennyWiseThemeWithManager(themeManager = themeManager) {
-                val appLanguage by settingsDataStore.language.collectAsState(initial = "")
+                val appLanguage by settingsDataStore.language.collectAsState(initial = initialLanguage)
                 val layoutDirection = if (
                     appLanguage.equals("iw", ignoreCase = true) ||
                     appLanguage.equals("he", ignoreCase = true)

--- a/app/src/main/java/com/pennywise/app/presentation/util/AppLocaleSupport.kt
+++ b/app/src/main/java/com/pennywise/app/presentation/util/AppLocaleSupport.kt
@@ -1,0 +1,67 @@
+package com.pennywise.app.presentation.util
+
+import android.content.Context
+import android.os.Build
+import java.util.Locale
+
+/**
+ * Single source of truth for app-supported locales and RTL behavior.
+ *
+ * Keeping language canonicalization, fallback mapping, and RTL detection here
+ * prevents locale drift between application startup, runtime locale updates,
+ * and Compose layout direction.
+ */
+object AppLocaleSupport {
+    const val ENGLISH = "en"
+    const val HEBREW = "iw"
+    const val RUSSIAN = "ru"
+
+    private const val HEBREW_MODERN = "he"
+
+    private val supportedLanguageCodes = setOf(ENGLISH, HEBREW, RUSSIAN)
+    private val rtlLanguageCodes = setOf(HEBREW)
+
+    fun resolveSupportedLocale(languageCode: String?, context: Context? = null): Locale {
+        val canonicalCode = canonicalLanguageCode(languageCode)
+        val resolvedCode = canonicalCode ?: detectSupportedSystemLanguageCode(context)
+        return Locale(resolvedCode)
+    }
+
+    fun detectSupportedSystemLanguageCode(context: Context?): String {
+        val systemLanguage = getSystemLanguageCode(context)
+        return canonicalLanguageCode(systemLanguage) ?: ENGLISH
+    }
+
+    fun isRtlLanguage(languageCode: String?): Boolean {
+        val canonicalCode = canonicalLanguageCode(languageCode)
+        return canonicalCode != null && canonicalCode in rtlLanguageCodes
+    }
+
+    fun isLanguageSupported(languageCode: String): Boolean {
+        val canonicalCode = canonicalLanguageCode(languageCode)
+        return canonicalCode != null && canonicalCode in supportedLanguageCodes
+    }
+
+    fun canonicalLanguageCode(languageCode: String?): String? {
+        return when {
+            languageCode.equals(ENGLISH, ignoreCase = true) -> ENGLISH
+            languageCode.equals(HEBREW, ignoreCase = true) ||
+                languageCode.equals(HEBREW_MODERN, ignoreCase = true) -> HEBREW
+            languageCode.equals(RUSSIAN, ignoreCase = true) -> RUSSIAN
+            else -> null
+        }
+    }
+
+    fun supportedLanguageCodes(): Set<String> = supportedLanguageCodes
+
+    private fun getSystemLanguageCode(context: Context?): String? {
+        return context?.let { safeContext ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                safeContext.resources.configuration.locales[0]?.language
+            } else {
+                @Suppress("DEPRECATION")
+                safeContext.resources.configuration.locale?.language
+            }
+        } ?: Locale.getDefault().language
+    }
+}

--- a/app/src/main/java/com/pennywise/app/presentation/util/LocaleManager.kt
+++ b/app/src/main/java/com/pennywise/app/presentation/util/LocaleManager.kt
@@ -22,10 +22,11 @@ class LocaleManager @Inject constructor() {
      * @return The updated context with the new locale
      */
     fun updateLocale(context: Context, languageCode: String): Context {
-        val locale = when (languageCode) {
-            "en" -> Locale("en")
-            "iw" -> Locale("iw")
-            "ru" -> Locale("ru")
+        val locale = when {
+            languageCode.equals("en", ignoreCase = true) -> Locale("en")
+            languageCode.equals("iw", ignoreCase = true) ||
+                languageCode.equals("he", ignoreCase = true) -> Locale("iw")
+            languageCode.equals("ru", ignoreCase = true) -> Locale("ru")
             else -> Locale.getDefault()
         }
         

--- a/app/src/main/java/com/pennywise/app/presentation/util/LocaleManager.kt
+++ b/app/src/main/java/com/pennywise/app/presentation/util/LocaleManager.kt
@@ -27,7 +27,7 @@ class LocaleManager @Inject constructor() {
             languageCode.equals("iw", ignoreCase = true) ||
                 languageCode.equals("he", ignoreCase = true) -> Locale("iw")
             languageCode.equals("ru", ignoreCase = true) -> Locale("ru")
-            else -> Locale.getDefault()
+            else -> mapSystemLocaleToSupportedLocale(context)
         }
         
         return updateResources(context, locale)
@@ -86,6 +86,27 @@ class LocaleManager @Inject constructor() {
         context.resources.updateConfiguration(configuration, context.resources.displayMetrics)
         
         return updatedContext
+    }
+
+    /**
+     * Maps the device locale to a supported app locale.
+     * Unsupported system languages default to English (LTR).
+     */
+    private fun mapSystemLocaleToSupportedLocale(context: Context): Locale {
+        val systemLanguage = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            context.resources.configuration.locales[0]?.language
+        } else {
+            @Suppress("DEPRECATION")
+            context.resources.configuration.locale?.language
+        } ?: Locale.getDefault().language
+
+        return when {
+            systemLanguage.equals("ru", ignoreCase = true) -> Locale("ru")
+            systemLanguage.equals("he", ignoreCase = true) ||
+                systemLanguage.equals("iw", ignoreCase = true) -> Locale("iw")
+            systemLanguage.equals("en", ignoreCase = true) -> Locale("en")
+            else -> Locale("en")
+        }
     }
     
     /**

--- a/app/src/main/java/com/pennywise/app/presentation/util/SettingsManager.kt
+++ b/app/src/main/java/com/pennywise/app/presentation/util/SettingsManager.kt
@@ -1,8 +1,6 @@
 package com.pennywise.app.presentation.util
 
-import android.content.Context
 import com.pennywise.app.data.util.SettingsDataStore
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -13,8 +11,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class SettingsManager @Inject constructor(
-    private val settingsDataStore: SettingsDataStore,
-    @ApplicationContext private val context: Context
+    private val settingsDataStore: SettingsDataStore
 ) {
     
     /**
@@ -22,12 +19,8 @@ class SettingsManager @Inject constructor(
      */
     suspend fun saveLanguagePreference(languageCode: String) {
         
-        // Save to DataStore via SettingsDataStore
+        // SettingsDataStore handles DataStore + startup SharedPreferences sync.
         settingsDataStore.setLanguage(languageCode)
-        
-        // Also save to SharedPreferences for app startup compatibility
-        val sharedPrefs = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        sharedPrefs.edit().putString("language", languageCode).apply()
     }
     
     /**
@@ -42,12 +35,8 @@ class SettingsManager @Inject constructor(
      */
     suspend fun saveCurrencyPreference(currencyCode: String) {
         
-        // Save to DataStore via SettingsDataStore
+        // SettingsDataStore handles DataStore + startup SharedPreferences sync.
         settingsDataStore.setCurrency(currencyCode)
-        
-        // Also save to SharedPreferences for app startup compatibility
-        val sharedPrefs = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
-        sharedPrefs.edit().putString("currency", currencyCode).apply()
     }
     
     /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches app-wide locale and layout direction behavior and persists settings across both DataStore and SharedPreferences; mistakes here could cause incorrect language/layout at startup or during activity restarts.
> 
> **Overview**
> Fixes intermittent RTL/LTR switching by introducing `AppLocaleSupport` as the single source of truth for supported language codes, canonicalization (including `he`→`iw`), locale resolution, and RTL detection.
> 
> Compose now derives `LocalLayoutDirection` from the persisted app language (RTL only for Hebrew) by observing `settingsDataStore.language`, seeded from startup `SharedPreferences`. Locale persistence is also tightened by syncing `language`/`currency` writes from `SettingsDataStore` into `app_preferences`, and first-run device-locale detection is immediately persisted so startup, runtime locale updates, and Compose layout direction stay consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f82eaf7093a30d63b379806ccbd8411db943f8bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->